### PR TITLE
Fix and update `testing` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,38 +92,14 @@ func TestMain(t *testing.T) {
 	// You can provide CheckSelectBuilder, CheckUpdateBuilder 
 	// or CheckDeleteBuilder functions for checking sql query.
 	// Or use mockdb.DefaultSelect for skipping sql checks
-	mockDB := mockdb.NewDAO("entries", cfg.Log(),
-		mockdb.MockData{
-			CheckSelectBuilder: mockdb.DefaultSelect,
-			CheckUpdateBuilder: mockdb.DefaultUpdate,
-			CheckDeleteBuilder: mockdb.DefaultDelete,
-			Entry:              Entry{},
-			Error:              nil,
-			Ok:                 false,
-			T:                  t,
-		},
-		mockdb.MockData{
-			CheckSelectBuilder: mockdb.DefaultSelect,
-			CheckUpdateBuilder: mockdb.DefaultUpdate,
-			CheckDeleteBuilder: mockdb.DefaultDelete,
-			Entry: Entry{
-				Id:   1,
-				Name: "First Entry",
-			},
-			Error: nil,
-			Ok:    true,
-			T:     t,
-		},
-		mockdb.MockData{
-			CheckSelectBuilder: mockdb.DefaultSelect,
-			CheckUpdateBuilder: mockdb.DefaultUpdate,
-			CheckDeleteBuilder: mockdb.DefaultDelete,
-			Entry:              nil,
-			Error:              nil,
-			Ok:                 true,
-			T:                  t,
-		},
-	)
+	mockDB := mockdb.New(t, "test").
+		Add(Entry{}, false, nil).
+		Add(Entry{
+			Id: 1,
+			Name: "First Entry",
+		}, true, nil).
+		Add(nil, true, nil).
+		DAO()
 	
 	var entry Entry
 	

--- a/README.md
+++ b/README.md
@@ -86,12 +86,7 @@ type Entry struct {
 }
 
 func TestMain(t *testing.T) {
-	cfg := config.New(kv.MustFromEnv())
-	
 	// Creating mock db with sql responses order
-	// You can provide CheckSelectBuilder, CheckUpdateBuilder 
-	// or CheckDeleteBuilder functions for checking sql query.
-	// Or use mockdb.DefaultSelect for skipping sql checks
 	mockDB := mockdb.New(t, "test").
 		Add(Entry{}, false, nil).
 		Add(Entry{

--- a/testing/mock_dao.go
+++ b/testing/mock_dao.go
@@ -4,11 +4,11 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+	"testing"
 
 	sq "github.com/Masterminds/squirrel"
 	pg "github.com/olegfomenko/pg-dao"
 	"gitlab.com/distributed_lab/kit/pgdb"
-	"gitlab.com/distributed_lab/logan/v3"
 	"gitlab.com/distributed_lab/logan/v3/errors"
 )
 
@@ -18,61 +18,61 @@ type dao struct {
 	upd        sq.UpdateBuilder
 	dlt        sq.DeleteBuilder
 	mocksOrder *[]MockData
-	log        *logan.Entry
+	t          *testing.T
 }
 
-func NewDAO(tableName string, log *logan.Entry, mocks ...MockData) pg.DAO {
+func NewDAO(tableName string, t *testing.T) pg.DAO {
 	return &dao{
 		tableName:  tableName,
 		sql:        sq.Select(tableName + ".*").From(tableName),
 		upd:        sq.Update(tableName),
 		dlt:        sq.Delete(tableName),
-		mocksOrder: &mocks,
-		log:        log,
+		mocksOrder: nil,
+		t:          t,
 	}
 }
 
 func (d *dao) Clone() pg.DAO {
-	d.log.Debug("Cloning dao")
+	d.t.Log("Cloning dao")
 	return &dao{
 		tableName:  d.tableName,
 		sql:        sq.Select(d.tableName + ".*").From(d.tableName),
 		upd:        sq.Update(d.tableName),
 		dlt:        sq.Delete(d.tableName),
 		mocksOrder: d.mocksOrder,
-		log:        d.log,
+		t:          d.t,
 	}
 }
 
 func (d *dao) New() pg.DAO {
-	d.log.Debug("Initializing new raws")
+	d.t.Log("Initializing new raws")
 	return &dao{
 		tableName:  d.tableName,
 		sql:        sq.Select(d.tableName + ".*").From(d.tableName),
 		upd:        sq.Update(d.tableName),
 		dlt:        sq.Delete(d.tableName),
 		mocksOrder: d.mocksOrder,
-		log:        d.log,
+		t:          d.t,
 	}
 }
 
 func (d *dao) Count() pg.DAO {
-	d.log.Debug("Counting records")
+	d.t.Log("Counting records")
 	return &dao{
 		tableName:  d.tableName,
 		sql:        sq.Select("count(*)").From(d.tableName),
 		upd:        sq.Update(d.tableName),
 		dlt:        sq.Delete(d.tableName),
 		mocksOrder: d.mocksOrder,
-		log:        d.log,
+		t:          d.t,
 	}
 }
 
 func (d *dao) Create(dto interface{}) (int64, error) {
-	d.log.Debug("Saving new record ", dto)
+	d.t.Log("Saving new record ", dto)
 
 	if len(*d.mocksOrder) == 0 {
-		panic("empty mocks")
+		d.t.Fatal("empty mocks")
 	}
 
 	mock := (*d.mocksOrder)[0]
@@ -99,37 +99,37 @@ func (d *dao) Create(dto interface{}) (int64, error) {
 // }
 
 func (d *dao) FilterByID(id int64) pg.DAO {
-	d.log.Debug("Filtering by id: ", id)
+	d.t.Logf("Filtering by id: %d", id)
 	d.sql = d.sql.Where(sq.Eq{pg.IdColumn: id})
 	return d
 }
 
 func (d *dao) FilterGreater(col string, val interface{}) pg.DAO {
-	d.log.Debug("Filtering greater column:", col, " value: ", val)
+	d.t.Logf("Filtering greater column: %s value: %v", col, val)
 	d.sql = d.sql.Where(sq.Gt{col: val})
 	return d
 }
 
 func (d *dao) FilterLess(col string, val interface{}) pg.DAO {
-	d.log.Debug("Filtering less column:", col, " value: ", val)
+	d.t.Logf("Filtering less column: %s value: %v", col, val)
 	d.sql = d.sql.Where(sq.Lt{col: val})
 	return d
 }
 
 func (d *dao) FilterByColumn(col string, val interface{}) pg.DAO {
-	d.log.Debug("Filtering by column:", col, " value: ", val)
+	d.t.Logf("Filtering by column: %s value: %v", col, val)
 	d.sql = d.sql.Where(sq.Eq{col: val})
 	return d
 }
 
 func (d *dao) Get(dto interface{}) (bool, error) {
-	d.log.Debug("Getting record")
+	d.t.Log("Getting record")
 	if reflect.ValueOf(dto).Type().Kind() != reflect.Ptr {
 		return false, errors.New("argument is not a pointer")
 	}
 
 	if len(*d.mocksOrder) == 0 {
-		panic("empty mocks")
+		d.t.Fatal("empty mocks")
 	}
 
 	mock := (*d.mocksOrder)[0]
@@ -143,13 +143,13 @@ func (d *dao) Get(dto interface{}) (bool, error) {
 }
 
 func (d *dao) Select(list interface{}) error {
-	d.log.Debug("Selecting record")
+	d.t.Log("Selecting record")
 	if reflect.ValueOf(list).Type().Kind() != reflect.Ptr {
 		return errors.New("argument is not a slice pointer")
 	}
 
 	if len(*d.mocksOrder) == 0 {
-		panic("empty mocks")
+		d.t.Fatal("empty mocks")
 	}
 
 	mock := (*d.mocksOrder)[0]
@@ -163,39 +163,39 @@ func (d *dao) Select(list interface{}) error {
 }
 
 func (d *dao) Limit(limit uint64) pg.DAO {
-	d.log.Debug("Limiting rows: ", limit)
+	d.t.Logf("Limiting rows: %d", limit)
 	d.sql = d.sql.Limit(limit)
 	return d
 }
 
 func (d *dao) OrderByDesc(col string) pg.DAO {
-	d.log.Debug("Ordering descending column: ", col)
+	d.t.Logf("Ordering descending column: %s", col)
 	d.sql = d.sql.OrderBy(fmt.Sprintf("%s %s", col, pg.OrderDescending))
 	return d
 }
 
 func (d *dao) OrderByAsc(col string) pg.DAO {
-	d.log.Debug("Ordering ascending column: ", col)
+	d.t.Logf("Ordering ascending column: %s", col)
 	d.sql = d.sql.OrderBy(fmt.Sprintf("%s %s", col, pg.OrderAscending))
 	return d
 }
 
 func (d *dao) UpdateWhereID(id int64) pg.DAO {
-	d.log.Debug("Updating by id: ", id)
+	d.t.Logf("Updating by id: %d", id)
 	d.upd = d.upd.Where(sq.Eq{pg.IdColumn: id})
 	return d
 }
 
 func (d *dao) UpdateColumn(col string, val interface{}) pg.DAO {
-	d.log.Debug("Updating column:", col, " value: ", val)
+	d.t.Logf("Updating column: %s value: %v", col, val)
 	d.upd = d.upd.Set(col, val)
 	return d
 }
 
 func (d *dao) Update() error {
-	d.log.Debug("Updating record")
+	d.t.Log("Updating record")
 	if len(*d.mocksOrder) == 0 {
-		panic("empty mocks")
+		d.t.Fatal("empty mocks")
 	}
 
 	mock := (*d.mocksOrder)[0]
@@ -208,21 +208,21 @@ func (d *dao) Update() error {
 }
 
 func (d *dao) DeleteWhereVal(col string, val interface{}) pg.DAO {
-	d.log.Debug("Deleting where column:", col, " value: ", val)
+	d.t.Log("Deleting where column:", col, " value: ", val)
 	d.dlt = d.dlt.Where(sq.Eq{col: val})
 	return d
 }
 
 func (d *dao) DeleteWhereID(id int64) pg.DAO {
-	d.log.Debug("Deleting by id: ", id)
+	d.t.Logf("Deleting by id: %d", id)
 	d.dlt = d.dlt.Where(sq.Eq{pg.IdColumn: id})
 	return d
 }
 
 func (d *dao) Delete() error {
-	d.log.Debug("Deleting record")
+	d.t.Log("Deleting record")
 	if len(*d.mocksOrder) == 0 {
-		panic("empty mocks")
+		d.t.Fatal("empty mocks")
 	}
 
 	mock := (*d.mocksOrder)[0]
@@ -235,25 +235,25 @@ func (d *dao) Delete() error {
 }
 
 func (d *dao) Page(params pgdb.OffsetPageParams) pg.DAO {
-	d.log.Debug("Applying page parms")
+	d.t.Log("Applying page parms")
 	d.sql = params.ApplyTo(d.sql, "id")
 	return d
 }
 
 func (d *dao) Transaction(fn func(q pg.DAO) error) (err error) {
-	d.log.Debug("Starting db transaction")
-	defer d.log.Debug("Finishing db transaction")
+	d.t.Log("Starting db transaction")
+	defer d.t.Log("Finishing db transaction")
 	return fn(d)
 }
 
 func (d *dao) TransactionSerializable(fn func(q pg.DAO) error) error {
-	d.log.Debug("Starting db serializable transaction")
-	defer d.log.Debug("Finishing db serializable transaction")
+	d.t.Log("Starting db serializable transaction")
+	defer d.t.Log("Finishing db serializable transaction")
 	return fn(d)
 }
 
 func (d *dao) TransactionWithLevel(level sql.IsolationLevel, fn func(q pg.DAO) error) error {
-	d.log.Debug("Starting db transaction with level: ", level)
-	defer d.log.Debug("Finishing db transaction with level: ", level)
+	d.t.Log("Starting db transaction with level: ", level)
+	defer d.t.Logf("Finishing db transaction with level: %d", level)
 	return fn(d)
 }

--- a/testing/mock_dao.go
+++ b/testing/mock_dao.go
@@ -82,6 +82,46 @@ func (d *dao) Create(dto interface{}) (int64, error) {
 	return mock.Entry.(int64), mock.Error
 }
 
+// NOTE: Not defined in DAO interface
+//
+// func (d *dao) FilterOnlyAfter(time time.Time) pg.DAO {
+// 	d.log.Debug("Filtering after time: ", time.String())
+// 	d.sql = d.sql.Where(sq.Gt{pg.CreatedAtColumn: time})
+// 	return d
+// }
+
+// NOTE: Not defined in DAO interface
+//
+// func (d *dao) FilterOnlyBefore(time time.Time) pg.DAO {
+// 	d.log.Debug("Filtering before time: ", time.String())
+// 	d.sql = d.sql.Where(sq.Lt{pg.CreatedAtColumn: time})
+// 	return d
+// }
+
+func (d *dao) FilterByID(id int64) pg.DAO {
+	d.log.Debug("Filtering by id: ", id)
+	d.sql = d.sql.Where(sq.Eq{pg.IdColumn: id})
+	return d
+}
+
+func (d *dao) FilterGreater(col string, val interface{}) pg.DAO {
+	d.log.Debug("Filtering greater column:", col, " value: ", val)
+	d.sql = d.sql.Where(sq.Gt{col: val})
+	return d
+}
+
+func (d *dao) FilterLess(col string, val interface{}) pg.DAO {
+	d.log.Debug("Filtering less column:", col, " value: ", val)
+	d.sql = d.sql.Where(sq.Lt{col: val})
+	return d
+}
+
+func (d *dao) FilterByColumn(col string, val interface{}) pg.DAO {
+	d.log.Debug("Filtering by column:", col, " value: ", val)
+	d.sql = d.sql.Where(sq.Eq{col: val})
+	return d
+}
+
 func (d *dao) Get(dto interface{}) (bool, error) {
 	d.log.Debug("Getting record")
 	if reflect.ValueOf(dto).Type().Kind() != reflect.Ptr {
@@ -122,72 +162,6 @@ func (d *dao) Select(list interface{}) error {
 	return mock.Error
 }
 
-func (d *dao) Delete() error {
-	d.log.Debug("Deleting record")
-	if len(*d.mocksOrder) == 0 {
-		panic("empty mocks")
-	}
-
-	mock := (*d.mocksOrder)[0]
-	next := (*d.mocksOrder)[1:]
-	*d.mocksOrder = next
-
-	mock.CheckDeleteBuilder(d.dlt)
-
-	return mock.Error
-}
-
-func (d *dao) Update() error {
-	d.log.Debug("Updating record")
-	if len(*d.mocksOrder) == 0 {
-		panic("empty mocks")
-	}
-
-	mock := (*d.mocksOrder)[0]
-	next := (*d.mocksOrder)[1:]
-	*d.mocksOrder = next
-
-	mock.CheckUpdateBuilder(d.upd)
-
-	return mock.Error
-}
-
-func (d *dao) FilterByID(id int64) pg.DAO {
-	d.log.Debug("Filtering by id: ", id)
-	d.sql = d.sql.Where(sq.Eq{pg.IdColumn: id})
-	return d
-}
-
-// func (d *dao) FilterOnlyAfter(time time.Time) pg.DAO {
-// 	d.log.Debug("Filtering after time: ", time.String())
-// 	d.sql = d.sql.Where(sq.Gt{pg.CreatedAtColumn: time})
-// 	return d
-// }
-
-// func (d *dao) FilterOnlyBefore(time time.Time) pg.DAO {
-// 	d.log.Debug("Filtering before time: ", time.String())
-// 	d.sql = d.sql.Where(sq.Lt{pg.CreatedAtColumn: time})
-// 	return d
-// }
-
-func (d *dao) FilterGreater(col string, val interface{}) pg.DAO {
-	d.log.Debug("Filtering greater column:", col, " value: ", val)
-	d.sql = d.sql.Where(sq.Gt{col: val})
-	return d
-}
-
-func (d *dao) FilterLess(col string, val interface{}) pg.DAO {
-	d.log.Debug("Filtering less column:", col, " value: ", val)
-	d.sql = d.sql.Where(sq.Lt{col: val})
-	return d
-}
-
-func (d *dao) FilterByColumn(col string, val interface{}) pg.DAO {
-	d.log.Debug("Filtering by column:", col, " value: ", val)
-	d.sql = d.sql.Where(sq.Eq{col: val})
-	return d
-}
-
 func (d *dao) Limit(limit uint64) pg.DAO {
 	d.log.Debug("Limiting rows: ", limit)
 	d.sql = d.sql.Limit(limit)
@@ -218,6 +192,21 @@ func (d *dao) UpdateColumn(col string, val interface{}) pg.DAO {
 	return d
 }
 
+func (d *dao) Update() error {
+	d.log.Debug("Updating record")
+	if len(*d.mocksOrder) == 0 {
+		panic("empty mocks")
+	}
+
+	mock := (*d.mocksOrder)[0]
+	next := (*d.mocksOrder)[1:]
+	*d.mocksOrder = next
+
+	mock.CheckUpdateBuilder(d.upd)
+
+	return mock.Error
+}
+
 func (d *dao) DeleteWhereVal(col string, val interface{}) pg.DAO {
 	d.log.Debug("Deleting where column:", col, " value: ", val)
 	d.dlt = d.dlt.Where(sq.Eq{col: val})
@@ -229,6 +218,22 @@ func (d *dao) DeleteWhereID(id int64) pg.DAO {
 	d.dlt = d.dlt.Where(sq.Eq{pg.IdColumn: id})
 	return d
 }
+
+func (d *dao) Delete() error {
+	d.log.Debug("Deleting record")
+	if len(*d.mocksOrder) == 0 {
+		panic("empty mocks")
+	}
+
+	mock := (*d.mocksOrder)[0]
+	next := (*d.mocksOrder)[1:]
+	*d.mocksOrder = next
+
+	mock.CheckDeleteBuilder(d.dlt)
+
+	return mock.Error
+}
+
 func (d *dao) Page(params pgdb.OffsetPageParams) pg.DAO {
 	d.log.Debug("Applying page parms")
 	d.sql = params.ApplyTo(d.sql, "id")

--- a/testing/mock_entry.go
+++ b/testing/mock_entry.go
@@ -1,20 +1,7 @@
 package testing
 
-import (
-	sq "github.com/Masterminds/squirrel"
-	"testing"
-)
-
 type MockData struct {
-	CheckSelectBuilder func(builder sq.SelectBuilder)
-	CheckUpdateBuilder func(builder sq.UpdateBuilder)
-	CheckDeleteBuilder func(builder sq.DeleteBuilder)
-	Entry              interface{}
-	Error              error
-	Ok                 bool
-	T                  *testing.T
+	Entry interface{}
+	Error error
+	Ok    bool
 }
-
-func DefaultSelect(builder sq.SelectBuilder) {}
-func DefaultUpdate(builder sq.UpdateBuilder) {}
-func DefaultDelete(builder sq.DeleteBuilder) {}

--- a/testing/mock_entry.go
+++ b/testing/mock_entry.go
@@ -1,7 +1,24 @@
 package testing
 
+import (
+	"testing"
+
+	sq "github.com/Masterminds/squirrel"
+)
+
+type QueryUpdateChecker func(*testing.T, sq.UpdateBuilder)
+type QueryDeleteChecker func(*testing.T, sq.DeleteBuilder)
+type QuerySelectChecker func(*testing.T, sq.SelectBuilder)
+
+func DefaultQueryUpdateChecker(*testing.T, sq.UpdateBuilder) {}
+func DefaultQueryDeleteChecker(*testing.T, sq.DeleteBuilder) {}
+func DefaultQuerySelectChecker(*testing.T, sq.SelectBuilder) {}
+
 type MockData struct {
-	Entry interface{}
-	Error error
-	Ok    bool
+	selectChecker QuerySelectChecker
+	updateChecker QueryUpdateChecker
+	deleteChecker QueryDeleteChecker
+	Entry         interface{}
+	Error         error
+	Ok            bool
 }


### PR DESCRIPTION
- Now `dao` from `testing` implements `DAO` interface
- All logs in `testing` are replaced with `testing.T.Log` from stdlib to make controlable logging with `-v` flag in `go test`
- Redesign mockdb creation with more short form