### PR TITLE
Add method for accessing raw pgdb.DB struct

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,4 +49,6 @@ type DAO interface {
 	Transaction(fn func(q DAO) error) error
 	TransactionSerializable(fn func(q DAO) error) error
 	TransactionWithLevel(level sql.IsolationLevel, fn func(q DAO) error) error
+
+	ExecRaw(func(raw *pgdb.DB) error) error
 }

--- a/postgres.go
+++ b/postgres.go
@@ -204,3 +204,7 @@ func (d *dao) TransactionWithLevel(level sql.IsolationLevel, fn func(q DAO) erro
 		return fn(d)
 	})
 }
+
+func (d *dao) ExecRaw(fn func(raw *pgdb.DB) error) error {
+	return fn(d.db)
+}


### PR DESCRIPTION
This is needed for using the DAO interface for any kind of SQL queries, so the user could implement any arbitrary logic